### PR TITLE
Package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nshmdb"
+authors = "QuakeCoRE"
+description = "A library for working with 2022 NSHM fault geometry"
+readme = "README.md"
+requires-python = ">=3.7"
+dynamic = ["dependencies", "version"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nshmdb"
-authors = "QuakeCoRE"
+authors = [{name="QuakeCoRE"}]
 description = "A library for working with 2022 NSHM fault geometry"
 readme = "README.md"
 requires-python = ">=3.7"
 dynamic = ["dependencies", "version"]
 
+[project.scripts]
+nshm_db_generator = "nshmdb.scripts.nshm_db_generator:app"
+
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy
 pandas
 pygments
 pygmt
-qcore
+qcore @ git+https://github.com/ucgmsim/qcore
 scipy
 tqdm
 typer

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
Sets the git project so that it can be installed via `pip` and used from other projects. It is using pyproject.toml primarily, rather than the legacy setup.py. To maintain compatibility with legacy systems that might require a setup.py file, I have written a stub file that just bootstraps the pyproject.toml installation as per [the official setuptools package documentation](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html). The dependencies are dynamically sourced from requirements.txt. I think this splits the difference between:

1. Using a modern build-system for the package that is less brittle and easier to maintain.
2. Addressing @joelridden's concerns about using different package managers and virtual environment workflows by still maintaining a requirements.txt file.
3. Addressing @claudio525's concerns about mamba and miniforge installations by still supporting setup.py (but without duplicating work by maintaining both in parallel).

I will confirm and check that mamba will work with this setup. I do not anticipate problems with this because otherwise almost no pip package would work with mamba.