### PR TITLE
Fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
-dataclasses
+# dataclasses
 geojson
 numpy
 pandas
-pygments
-pygmt
-qcore
-scipy
+qcore @ git+https://github.com/ucgmsim/qcore
+pygmt_helper @ https://github.com/ucgmsim/pygmt_helper
 tqdm
 typer


### PR DESCRIPTION
Small PR fixes dependencies per deptry. The `dataclasses` dependency is commented because it is only used for Python 3.7 so deptry complains that this dependency is not used.
Once the pyproject.toml changes in #5 I can add an exception to the pyproject.toml file for `dataclasses` and then uncomment again.
