### PR TITLE
feat(nshm_db_generator): Use the from_trace method

### DIFF
--- a/nshmdb/nshmdb.py
+++ b/nshmdb/nshmdb.py
@@ -31,10 +31,10 @@ from typing import Optional
 
 import duckdb
 import numpy as np
-from qcore import coordinates
-from source_modelling.sources import Fault, Plane
 
 from nshmdb import query
+from qcore import coordinates
+from source_modelling.sources import Fault, Plane
 
 
 @dataclasses.dataclass
@@ -94,6 +94,13 @@ class NSHMDB:
     db_filepath: Path
 
     def __init__(self, db_filepath: Path):
+        """Initialise the NSHMDB instance.
+
+        Parameters
+        ----------
+        db_filepath : Path
+            Path to the SQLite database file.
+        """
         self.db_filepath = db_filepath
 
     def create(self):

--- a/nshmdb/plotting/rupture.py
+++ b/nshmdb/plotting/rupture.py
@@ -10,6 +10,7 @@ Functions:
 from pathlib import Path
 
 import numpy as np
+
 from pygmt_helper import plotting
 from source_modelling.sources import Fault
 

--- a/nshmdb/scripts/nshm_db_generator.py
+++ b/nshmdb/scripts/nshm_db_generator.py
@@ -30,11 +30,13 @@ from typing import Annotated
 import geojson
 import numpy as np
 import pandas as pd
-import qcore.coordinates
+import shapely
 import typer
 from geojson import FeatureCollection
-from nshmdb.nshmdb import NSHMDB
+from qcore import coordinates
 from source_modelling.sources import Fault, Plane
+
+from nshmdb.nshmdb import NSHMDB
 
 app = typer.Typer()
 
@@ -65,37 +67,34 @@ def extract_faults_from_info(
     faults = {}
     for i in range(len(fault_info_list.features)):
         fault_feature = fault_info_list[i]
-        fault_trace = list(geojson.utils.coords(fault_feature))
+        fault_trace = shapely.LineString(
+            coordinates.wgs_depth_to_nztm(
+                np.array(list(geojson.utils.coords(fault_feature)))[:, ::-1]
+            )
+        )
+        fault_trace = shapely.simplify(fault_trace, 10)
+        trace_coords = np.array(fault_trace.coords)
         name = fault_feature.properties["FaultName"]
+        bottom = fault_feature.properties["LowDepth"]
         dip_dir = fault_feature.properties["DipDir"]
         dip = fault_feature.properties["DipDeg"]
-        bottom = fault_feature.properties["LowDepth"]
-        if dip == 90:
-            projected_width = 0
-        else:
-            projected_width = bottom / np.tan(np.radians(dip))
         planes = []
-        for i in range(len(fault_trace) - 1):
-            top_left = qcore.coordinates.wgs_depth_to_nztm(
-                np.append(fault_trace[i][::-1], 0)
+        for j in range(len(trace_coords) - 1):
+            top_left = trace_coords[j]
+            top_right = trace_coords[j + 1]
+            planes.append(
+                Plane.from_nztm_trace(
+                    np.array([top_left, top_right]),
+                    0,
+                    bottom,
+                    dip,
+                    coordinates.great_circle_bearing_to_nztm_bearing(
+                        coordinates.nztm_to_wgs_depth(top_left), 1, dip_dir
+                    )
+                    if dip != 90
+                    else 0,
+                ),
             )
-            top_right = qcore.coordinates.wgs_depth_to_nztm(
-                np.append(fault_trace[i + 1][::-1], 0)
-            )
-            dip_dir_direction = (
-                np.array(
-                    [
-                        projected_width * np.cos(np.radians(dip_dir)),
-                        projected_width * np.sin(np.radians(dip_dir)),
-                        bottom,
-                    ]
-                )
-                * 1000
-            )
-            bottom_left = top_left + dip_dir_direction
-            bottom_right = top_right + dip_dir_direction
-            corners = np.array([top_left, top_right, bottom_right, bottom_left])
-            planes.append(Plane(corners))
         faults[name] = Fault(planes)
     return faults
 
@@ -127,9 +126,10 @@ def main(
     db = NSHMDB(sqlite_db_path)
     db.create()
 
-    with zipfile.ZipFile(
-        cru_solutions_zip_path, "r"
-    ) as cru_solutions_zip_file, db.connection() as conn:
+    with (
+        zipfile.ZipFile(cru_solutions_zip_path, "r") as cru_solutions_zip_file,
+        db.connection() as conn,
+    ):
         with cru_solutions_zip_file.open(
             str(FAULT_INFORMATION_PATH)
         ) as fault_info_handle:
@@ -194,13 +194,17 @@ def main(
                 )
 
         if not skip_rupture_creation:
-            with cru_solutions_zip_file.open(
-                str(RUPTURE_FAULT_JOIN_PATH)
-            ) as rupture_fault_join_handle, cru_solutions_zip_file.open(
-                str(RUPTURE_RATES_PATH)
-            ) as rupture_rates_handle, cru_solutions_zip_file.open(
-                str(RUPTURE_PROPERTIES_PATH)
-            ) as rupture_properties_path:
+            with (
+                cru_solutions_zip_file.open(
+                    str(RUPTURE_FAULT_JOIN_PATH)
+                ) as rupture_fault_join_handle,
+                cru_solutions_zip_file.open(
+                    str(RUPTURE_RATES_PATH)
+                ) as rupture_rates_handle,
+                cru_solutions_zip_file.open(
+                    str(RUPTURE_PROPERTIES_PATH)
+                ) as rupture_properties_path,
+            ):
                 rupture_rates = pd.read_csv(rupture_rates_handle).set_index(
                     "Rupture Index"
                 )

--- a/nshmdb/scripts/nshm_db_generator.py
+++ b/nshmdb/scripts/nshm_db_generator.py
@@ -33,10 +33,10 @@ import pandas as pd
 import shapely
 import typer
 from geojson import FeatureCollection
-from qcore import coordinates
-from source_modelling.sources import Fault, Plane
 
 from nshmdb.nshmdb import NSHMDB
+from qcore import coordinates
+from source_modelling.sources import Fault, Plane
 
 app = typer.Typer()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,50 @@ nshm_db_generator = "nshmdb.scripts.nshm_db_generator:app"
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 
+[tool.ruff.lint]
+extend-select = [
+  # isort imports
+  "I",
+  # Use r'\s+' rather than '\s+'
+  "W605",
+  # All the naming errors, like using camel case for function names.
+  "N",
+  # Missing docstrings in classes, methods, and functions
+  "D101",
+  "D102",
+  "D103",
+  "D105",
+  "D107",
+  # Use f-string instead of a format call
+  "UP032",
+  # Standard library import is deprecated
+  "UP035",
+  # Missing function argument type-annotation
+  "ANN001",
+  # Using except without specifying an exception type to catch
+  "BLE001"
+]
+ignore = ["D104"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.isort]
+known-first-party = [
+    "source_modelling",
+    "workflow",
+    "pygmt_helper",
+    "qcore",
+    "empirical",
+    "nshmdb",
+    "IM",
+    "mera"
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore no docstring in __init__.py
+"__init__.py" = ["D104"]
+# Ignore docstring errors in tests folder
+"tests/**.py" = ["D"]
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ geojson
 numpy<2
 pandas
 pygmt_helper @ git+https://github.com/ucgmsim/pygmt_helper.git
+pytest
 qcore @ git+https://github.com/ucgmsim/qcore.git
+shapely
 source_modelling @ git+https://github.com/ucgmsim/source_modelling.git
 typer
-pytest

--- a/tests/test_nshmdb.py
+++ b/tests/test_nshmdb.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+
 from nshmdb.nshmdb import NSHMDB, FaultInfo, Rupture
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,5 @@
 import pytest
+
 from nshmdb.query import (
     InfixOperator,
     Token,


### PR DESCRIPTION
This PR:

1. Uses the new `from_nztm_trace` function to construct planes,
2. Simplifies the geometry of the fault traces (to within 10m of the original geometry).


The latter point takes care of faults that have _tiny_ segments that pose a problem for numerical accuracy and SRF generation. You can see examples of the simplified traces below:

![plot_2](https://github.com/user-attachments/assets/77a320f8-1533-40eb-bd6d-0ab5fcd59ba5)
![plot_10](https://github.com/user-attachments/assets/29c154b2-0571-4aa0-8a61-262cb485d21e)
![plot_13](https://github.com/user-attachments/assets/0ad4515d-8ca4-4a7b-8f97-4c084781e49a)

There is a red trace in that same plot that is supposed to be the new trace, but it's so similar to the old trace that it is hard to distinguish.