### PR TITLE
Unsimplify shapely geometry

### DIFF
--- a/nshmdb/scripts/nshm_db_generator.py
+++ b/nshmdb/scripts/nshm_db_generator.py
@@ -72,7 +72,6 @@ def extract_faults_from_info(
                 np.array(list(geojson.utils.coords(fault_feature)))[:, ::-1]
             )
         )
-        fault_trace = shapely.simplify(fault_trace, 10)
         trace_coords = np.array(fault_trace.coords)
         name = fault_feature.properties["FaultName"]
         bottom = fault_feature.properties["LowDepth"]


### PR DESCRIPTION
Earlier, we introduced geometry simplification into the DB generation process. Ultimately, I decided this is best done later on in the pipeline (i.e. by the consumer of database data). This is because you can't unsimplify the geometry after you've already simplified it.