### PR TITLE
Small change to allow workflow to use convention-aware magnitudes without # ty: ignore

### DIFF
--- a/nshmdb/nshmdb.py
+++ b/nshmdb/nshmdb.py
@@ -34,6 +34,7 @@ import numpy as np
 
 from nshmdb import query
 from qcore import coordinates
+from source_modelling.moment import BoldM
 from source_modelling.sources import Fault, Plane
 
 
@@ -153,7 +154,7 @@ class NSHMDB:
         )
 
     def most_likely_fault(
-        self, rupture_id: int, parent_fault_magnitudes: dict[str, float]
+        self, rupture_id: int, parent_fault_magnitudes: dict[str, BoldM]
     ) -> dict[str, float]:
         """
         Calculate the cumulative activity rate for each fault involved in a specified rupture.
@@ -174,9 +175,10 @@ class NSHMDB:
         ----------
         rupture_id : int
             The unique identifier of the rupture to query.
-        parent_fault_magnitudes : dict[str, float]
-            A mapping of parent fault names to their expected magnitudes. These magnitudes
-            define the target values for querying activity rates in the MFD table.
+        parent_fault_magnitudes : dict[str, BoldM]
+            A mapping of parent fault names to their expected magnitudes (in the
+            `BoldM` convention). These magnitudes define the target values for
+            querying activity rates in the MFD table.
 
         Returns
         -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pygmt-helper
 pytest
 qcore-utils
 shapely
-source-modelling
+source-modelling>=2026.6.2
 typer

--- a/tests/test_nshmdb.py
+++ b/tests/test_nshmdb.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from nshmdb.nshmdb import NSHMDB, FaultInfo, Rupture
+from source_modelling.moment import BoldM
 
 
 @pytest.fixture
@@ -140,7 +141,7 @@ def test_query(alpine_fault_nshmdb: NSHMDB):
 
 
 def test_rates(alpine_fault_nshmdb: NSHMDB):
-    assert alpine_fault_nshmdb.most_likely_fault(1, {"Alpine Fault": 6.5}) == {
+    assert alpine_fault_nshmdb.most_likely_fault(1, {"Alpine Fault": BoldM(6.5)}) == {
         "Alpine Fault": 0.01
     }
 


### PR DESCRIPTION
Small change to allow `workflow` to use convention-aware magnitudes without [# ty: ignore](https://github.com/ucgmsim/workflow/pull/105/changes#diff-ffd57861586263ca8551df104409eaf61a2ea0c6e42e9d8c50011f53ed243c12R337).