### PR TITLE
PR review via PR comment mention

### DIFF
--- a/.github/workflows/deepseek-review.yml
+++ b/.github/workflows/deepseek-review.yml
@@ -3,6 +3,9 @@ name: DeepSeek PR Review
 on:
   pull_request_target:
     types: [opened, reopened, synchronize]
+  issue_comment:
+      types:
+        - created # Triggers when a comment is created on a PR    
 
 permissions:
   contents: read
@@ -15,5 +18,10 @@ jobs:
       - name: DeepSeek Code Review
         uses: hustcer/deepseek-review@v1
         with:
+          model: "deepseek-ai/DeepSeek-R1"
+          base-url: "https://api.siliconflow.cn/v1"
+          watch-mention: "@github-actions"
           chat-token: ${{ secrets.DEEPSEEK_API_KEY }}
+          allowed-associations: "OWNER,MEMBER,COLLABORATOR"
+
 

--- a/.github/workflows/deepseek-review.yml
+++ b/.github/workflows/deepseek-review.yml
@@ -4,8 +4,8 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize]
   issue_comment:
-      types:
-        - created # Triggers when a comment is created on a PR    
+    types:
+      - created # Triggers when a comment is created on a PR
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates the `.github/workflows/deepseek-review.yml` workflow to enhance how the DeepSeek code review bot is triggered and configured. The main changes include expanding the workflow trigger to include issue comments, and updating the DeepSeek review job to use a specific model, endpoint, and additional access controls.

**Workflow trigger enhancements:**
- The workflow now also runs when an issue comment is created on a pull request, not just on PR events.

**DeepSeek review job configuration updates:**
- Configured the job to use the `deepseek-ai/DeepSeek-R1` model and a custom API base URL (`https://api.siliconflow.cn/v1`).
- Added `watch-mention` so the bot responds when mentioned with `@github-actions`.
- Restricted triggering to users with specific associations: OWNER, MEMBER, or COLLABORATOR.