### PR TITLE
Improve PR review process with comment mentions

### DIFF
--- a/.github/workflows/deepseek-review.yml
+++ b/.github/workflows/deepseek-review.yml
@@ -3,6 +3,9 @@ name: DeepSeek PR Review
 on:
   pull_request_target:
     types: [opened, reopened, synchronize]
+  issue_comment:
+      types:
+        - created # Triggers when a comment is created on a PR    
 
 permissions:
   contents: read
@@ -15,5 +18,10 @@ jobs:
       - name: DeepSeek Code Review
         uses: hustcer/deepseek-review@v1
         with:
+          model: "deepseek-ai/DeepSeek-R1"
+          base-url: "https://api.siliconflow.cn/v1"
+          watch-mention: "@github-actions"
           chat-token: ${{ secrets.DEEPSEEK_API_KEY }}
+          allowed-associations: "OWNER,MEMBER,COLLABORATOR"
+
 

--- a/.github/workflows/deepseek-review.yml
+++ b/.github/workflows/deepseek-review.yml
@@ -4,8 +4,8 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize]
   issue_comment:
-      types:
-        - created # Triggers when a comment is created on a PR    
+    types:
+      - created # Triggers when a comment is created on a PR
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates the `.github/workflows/deepseek-review.yml` GitHub Actions workflow to enhance the DeepSeek PR review process. The main improvements include expanding the workflow triggers to respond to PR comments, configuring the DeepSeek review action with additional parameters, and tightening security by restricting who can trigger the review.

**Workflow trigger enhancements:**

* The workflow now also triggers on new comments created on pull requests, enabling review actions via PR comments.

**DeepSeek review action configuration:**

* Added configuration for the DeepSeek review action to specify the model (`deepseek-ai/DeepSeek-R1`), set a custom API base URL, and enable bot mention watching (`@github-actions`).
* Introduced an `allowed-associations` parameter, restricting who can trigger the review to repository owners, members, and collaborators, improving workflow security.