### PR TITLE
Deepseek pr

### DIFF
--- a/.github/workflows/deepseek-review.yml
+++ b/.github/workflows/deepseek-review.yml
@@ -3,9 +3,6 @@ name: DeepSeek PR Review
 on:
   pull_request_target:
     types: [opened, reopened, synchronize]
-  issue_comment:
-      types:
-        - created # Triggers when a comment is created on a PR    
 
 permissions:
   contents: read
@@ -18,10 +15,6 @@ jobs:
       - name: DeepSeek Code Review
         uses: hustcer/deepseek-review@v1
         with:
-          model: "deepseek-ai/DeepSeek-R1"
-          base-url: "https://api.siliconflow.cn/v1"
-          watch-mention: "@github-actions"
           chat-token: ${{ secrets.DEEPSEEK_API_KEY }}
-          allowed-associations: "OWNER,MEMBER,COLLABORATOR"
 
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/deepseek-review.yml` workflow configuration, primarily by simplifying the event triggers and removing some configuration options for the DeepSeek Code Review action.

Workflow trigger and configuration changes:

* Removed the `issue_comment` trigger, so the workflow now only runs on pull request events (`opened`, `reopened`, `synchronize`).
* Cleaned up the DeepSeek Code Review action configuration by removing the `model`, `base-url`, `watch-mention`, and `allowed-associations` options, leaving only the `chat-token` input.